### PR TITLE
Add pipeline command and multi-symbol support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ app/
 ## Demo Sequence
 
 ```bash
+# 0) One-shot pipeline across multiple symbols
+tradebot pipeline.run --symbols AAPL,MSFT,GOOG --timeframe 1h --start 2020-01-01 --generation GEN_001
+
 # 1) Pull historical data (mocked when offline)
 python -m app.cli data.pull --symbols AAPL --timeframe 1h --start 2020-01-01
 

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,0 +1,12 @@
+"""Allow running the CLI via `python -m app`."""
+from __future__ import annotations
+
+from .cli import app
+
+
+def main() -> None:
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/app/backtest/engine.py
+++ b/app/backtest/engine.py
@@ -54,7 +54,11 @@ def run_walk_forward(
 ) -> BacktestMetrics:
     ensure_directory(output_dir)
     signals = signals.reindex(returns.index).fillna(0)
-    strategy_returns = signals.shift().fillna(0) * returns
+    if isinstance(signals.index, pd.MultiIndex) and "symbol" in signals.index.names:
+        shifted = signals.groupby(level="symbol").shift().fillna(0)
+    else:
+        shifted = signals.shift().fillna(0)
+    strategy_returns = shifted * returns
     equity_curve = (1 + strategy_returns).cumprod()
     metrics = performance_metrics(equity_curve)
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -1,9 +1,11 @@
 """Command line interface for the simulator."""
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
+import joblib
 import pandas as pd
 import typer
 
@@ -26,6 +28,38 @@ def _load_price_data(path: Path) -> pd.DataFrame:
     return pd.read_parquet(path)
 
 
+def _parse_symbols(symbols: str) -> List[str]:
+    parsed = [sym.strip().upper() for sym in symbols.split(",") if sym.strip()]
+    if not parsed:
+        raise typer.Exit("At least one symbol must be provided")
+    return parsed
+
+
+def _cache_dir_for(dataset_id: str) -> Path:
+    path = settings.storage.cache_dir / dataset_id
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _compute_returns(price: pd.DataFrame) -> pd.Series:
+    frame = price.copy()
+    if "symbol" not in frame.columns:
+        frame["symbol"] = "__SINGLE__"
+    frame = frame.sort_values(["symbol", "timestamp"])
+    series = (
+        frame.set_index(["symbol", "timestamp"])["close"].groupby(level="symbol").pct_change()
+    )
+    return series.dropna()
+
+
+def _model_signals(model_path: Path, features: pd.DataFrame) -> pd.Series:
+    if not model_path.exists():
+        raise typer.Exit(f"Model artifact not found at {model_path}")
+    model = joblib.load(model_path)
+    preds = pd.Series(model.predict(features), index=features.index)
+    return preds.apply(lambda x: 0 if x == 0 else (1 if x > 0 else -1)).rename("signal")
+
+
 @app.command("data.pull")
 def data_pull(
     symbols: str,
@@ -34,7 +68,7 @@ def data_pull(
     end: str = "2020-12-31",
     adjust: bool = True,
 ) -> None:
-    symbol_list = [sym.strip().upper() for sym in symbols.split(",")]
+    symbol_list = _parse_symbols(symbols)
     frame, metadata = fetch_ohlcv(symbol_list, timeframe, start, end, adjust)
     registry.register_dataset(metadata.dataset_id, metadata.__dict__)
     typer.echo(f"Saved dataset {metadata.dataset_id} to {metadata.path}")
@@ -57,7 +91,7 @@ def features_build(dataset_id: Optional[str] = None) -> None:
     if dataset_id is None:
         raise typer.Exit("No dataset available")
     price = _load_price_data(settings.storage.data_dir / f"{dataset_id}.parquet")
-    features, path = build_feature_matrix(price, settings.storage.cache_dir)
+    features, path = build_feature_matrix(price, _cache_dir_for(dataset_id))
     typer.echo(f"Features saved to {path}")
 
 
@@ -67,7 +101,8 @@ def labels_build(dataset_id: Optional[str] = None, horizon: int = 24) -> None:
     if dataset_id is None:
         raise typer.Exit("No dataset available")
     price = _load_price_data(settings.storage.data_dir / f"{dataset_id}.parquet")
-    cls, reg = fixed_horizon_returns(price, horizon, output_dir=settings.storage.cache_dir)
+    cache_dir = _cache_dir_for(dataset_id)
+    cls, reg = fixed_horizon_returns(price, horizon, output_dir=cache_dir)
     typer.echo(f"Labels generated with {len(cls)} observations")
 
 
@@ -96,8 +131,9 @@ def train(
     if dataset_id is None:
         raise typer.Exit("No dataset available")
     price = _load_price_data(settings.storage.data_dir / f"{dataset_id}.parquet")
-    features, _ = build_feature_matrix(price, settings.storage.cache_dir)
-    labels, _ = fixed_horizon_returns(price, settings.training.horizon_bars)
+    cache_dir = _cache_dir_for(dataset_id)
+    features, _ = build_feature_matrix(price, cache_dir)
+    labels, _ = fixed_horizon_returns(price, settings.training.horizon_bars, output_dir=cache_dir)
     features, labels = features.align(labels, join="inner", axis=0)
     model_path = train_generation(generation, features, labels, model_name=model, cv_scheme=cv, max_iter=n_iters)
     typer.echo(f"Model saved to {model_path}")
@@ -113,16 +149,92 @@ def backtest(
     if dataset_id is None:
         raise typer.Exit("No dataset available")
     price = _load_price_data(settings.storage.data_dir / f"{dataset_id}.parquet")
-    features, _ = build_feature_matrix(price, settings.storage.cache_dir)
-    returns = price.set_index("timestamp")["close"].pct_change().dropna()
+    cache_dir = _cache_dir_for(dataset_id)
+    features, _ = build_feature_matrix(price, cache_dir)
+    returns = _compute_returns(price)
     if strategy == "ema_crossover":
         signals = ema_crossover.generate_signals(features)
+    elif strategy == "ml_classifier":
+        model_path = settings.storage.models_dir / generation / "model.joblib"
+        signals = _model_signals(model_path, features)
     else:
-        signals = features["returns_1"].apply(lambda x: 1 if x > 0 else -1)
+        raise typer.Exit(f"Unknown strategy '{strategy}'")
     backtest_dir = settings.storage.backtests_dir / generation
     metrics = run_walk_forward(signals, returns, generation, backtest_dir)
     generation_kpi_table([metrics], backtest_dir / "kpis.csv")
     typer.echo(f"Backtest metrics saved: {metrics}")
+
+
+@app.command("pipeline.run")
+def pipeline_run(
+    symbols: str,
+    timeframe: str = "1h",
+    start: str = "2020-01-01",
+    end: str = "2020-12-31",
+    adjust: bool = True,
+    generation: str = "GEN_001",
+    cv: str = "blocked",
+    n_iters: int = 10,
+    model: str = "gradient_boosting",
+    strategy: str = "ml_classifier",
+) -> None:
+    """End-to-end pipeline run for one generation."""
+
+    typer.echo(settings.simulation_warning)
+    symbol_list = _parse_symbols(symbols)
+    price, metadata = fetch_ohlcv(symbol_list, timeframe, start, end, adjust)
+    registry.register_dataset(metadata.dataset_id, metadata.__dict__)
+
+    cache_dir = _cache_dir_for(metadata.dataset_id)
+    features, _ = build_feature_matrix(price, cache_dir)
+    labels, _ = fixed_horizon_returns(price, settings.training.horizon_bars, output_dir=cache_dir)
+    features, labels = features.align(labels, join="inner", axis=0)
+
+    model_path = train_generation(
+        generation,
+        features,
+        labels,
+        model_name=model,
+        cv_scheme=cv,
+        max_iter=n_iters,
+    )
+
+    returns = _compute_returns(price)
+    if strategy == "ema_crossover":
+        signals = ema_crossover.generate_signals(features)
+    elif strategy == "ml_classifier":
+        signals = _model_signals(model_path, features)
+    else:
+        raise typer.Exit(f"Unknown strategy '{strategy}'")
+
+    backtest_dir = settings.storage.backtests_dir / generation
+    metrics = run_walk_forward(signals, returns, generation, backtest_dir)
+    generation_kpi_table([metrics], backtest_dir / "kpis.csv")
+
+    run_id = datetime.utcnow().strftime("RUN_%Y%m%d%H%M%S")
+    registry.register_run(
+        run_id,
+        {
+            "dataset_id": metadata.dataset_id,
+            "symbols": symbol_list,
+            "generation": generation,
+            "model": model,
+            "strategy": strategy,
+            "metrics": metrics.__dict__,
+        },
+    )
+
+    typer.echo(
+        " | ".join(
+            [
+                f"Run ID: {run_id}",
+                f"Dataset: {metadata.dataset_id}",
+                f"Generation: {generation}",
+                f"Model saved to {model_path}",
+                f"Backtest CAGR: {metrics.cagr:.2%}",
+            ]
+        )
+    )
 
 
 @app.command("report.run")

--- a/app/features/engineer.py
+++ b/app/features/engineer.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Tuple
+from typing import Dict, Tuple
 
 import pandas as pd
 
@@ -12,12 +12,26 @@ from .indicators import build_indicators
 
 def build_feature_matrix(price_frame: pd.DataFrame, output_dir: Path) -> Tuple[pd.DataFrame, Path]:
     ensure_directory(output_dir)
-    price_frame = price_frame.sort_values("timestamp")
-    price_frame = price_frame.set_index("timestamp")
-    features = build_indicators(price_frame)
-    features["returns_1"] = price_frame["close"].pct_change()
-    features["volatility_14"] = price_frame["close"].pct_change().rolling(14).std()
-    features = features.dropna().replace([pd.NA, pd.NaT], 0).fillna(0)
+    price_frame = price_frame.copy()
+    if "symbol" not in price_frame.columns:
+        price_frame["symbol"] = "__SINGLE__"
+
+    grouped = price_frame.sort_values(["symbol", "timestamp"]).groupby("symbol", sort=True)
+    feature_blocks: Dict[str, pd.DataFrame] = {}
+
+    for symbol, group in grouped:
+        indexed = group.set_index("timestamp")
+        block = build_indicators(indexed)
+        block["returns_1"] = indexed["close"].pct_change()
+        block["volatility_14"] = indexed["close"].pct_change().rolling(14).std()
+        block = block.dropna().replace([pd.NA, pd.NaT], 0).fillna(0)
+        feature_blocks[symbol] = block
+
+    if not feature_blocks:
+        features = pd.DataFrame()
+    else:
+        features = pd.concat(feature_blocks, names=["symbol", "timestamp"]).sort_index()
+
     path = output_dir / "features.parquet"
     try:
         features.to_parquet(path)

--- a/app/labels/fixed_horizon.py
+++ b/app/labels/fixed_horizon.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Dict, Tuple
 
-import numpy as np
 import pandas as pd
 
 from app.core.io import ensure_directory
@@ -16,13 +15,35 @@ def fixed_horizon_returns(
     threshold: float = 0.0,
     output_dir: Path | None = None,
 ) -> Tuple[pd.Series, pd.Series]:
-    price_frame = price_frame.sort_values("timestamp").set_index("timestamp")
-    future_price = price_frame["close"].shift(-horizon)
-    returns = future_price / price_frame["close"] - 1
-    classification = (returns > threshold).astype(int) - (returns < -threshold).astype(int)
-    regression = returns
+    price_frame = price_frame.copy()
+    if "symbol" not in price_frame.columns:
+        price_frame["symbol"] = "__SINGLE__"
+
+    price_frame = price_frame.sort_values(["symbol", "timestamp"])
+    classification_blocks: Dict[str, pd.Series] = {}
+    regression_blocks: Dict[str, pd.Series] = {}
+
+    for symbol, group in price_frame.groupby("symbol", sort=True):
+        indexed = group.set_index("timestamp")
+        future_price = indexed["close"].shift(-horizon)
+        returns = future_price / indexed["close"] - 1
+        cls = (returns > threshold).astype(int) - (returns < -threshold).astype(int)
+        classification_blocks[symbol] = cls.dropna()
+        regression_blocks[symbol] = returns.dropna()
+
+    if classification_blocks:
+        classification = pd.concat(classification_blocks, names=["symbol", "timestamp"]).sort_index()
+    else:
+        classification = pd.Series(dtype="int64")
+
+    if regression_blocks:
+        regression = pd.concat(regression_blocks, names=["symbol", "timestamp"]).sort_index()
+    else:
+        regression = pd.Series(dtype="float64")
+
     if output_dir is not None:
         ensure_directory(output_dir)
         classification.to_frame("label").to_parquet(output_dir / "labels_classification.parquet")
         regression.to_frame("target").to_parquet(output_dir / "labels_regression.parquet")
-    return classification.dropna(), regression.dropna()
+
+    return classification, regression

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ requires-python = ">=3.11"
 readme = "README.md"
 dependencies = []
 
+[project.scripts]
+tradebot = "app.cli:app"
+
 [tool.black]
 line-length = 88
 target-version = ["py311"]


### PR DESCRIPTION
## Summary
- add a `tradebot` console script and Python module entrypoint for easier CLI execution
- enhance the Typer CLI with multi-symbol aware helpers and a `pipeline.run` command that fetches, trains, and backtests in one step
- update feature/label generation and the backtest engine to operate on multi-symbol datasets without leakage

## Testing
- pytest *(fails: pandas not installed in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e080a6a0848321a93d068388d00232