### PR TITLE
Add Backtrader engine and historical training filters

### DIFF
--- a/app/backtest/__init__.py
+++ b/app/backtest/__init__.py
@@ -1,0 +1,13 @@
+"""Backtest utilities exposed at package level."""
+
+from .backtrader_engine import BacktraderConfig, run_backtrader_strategy
+from .engine import generation_kpi_table, performance_metrics, run_walk_forward
+
+__all__ = [
+    "BacktraderConfig",
+    "generation_kpi_table",
+    "performance_metrics",
+    "run_backtrader_strategy",
+    "run_walk_forward",
+]
+

--- a/app/backtest/backtrader_engine.py
+++ b/app/backtest/backtrader_engine.py
@@ -1,0 +1,151 @@
+"""Backtrader-based backtesting utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Type
+
+import backtrader as bt
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from app.core.io import ensure_directory, save_json
+from app.core.types import BacktestMetrics
+
+from .engine import performance_metrics
+
+
+@dataclass
+class BacktraderConfig:
+    """Configuration for running Backtrader simulations."""
+
+    initial_cash: float = 100_000.0
+    commission: float = 0.001
+    slippage: float = 0.0
+    stake: float = 1.0
+
+
+class EMACrossoverStrategy(bt.Strategy):
+    params = dict(fast=5, slow=21, stake=1.0)
+
+    def __init__(self) -> None:  # pragma: no cover - behavior defined by Backtrader
+        self.fast = bt.ind.EMA(period=self.params.fast)
+        self.slow = bt.ind.EMA(period=self.params.slow)
+        self.crossover = bt.ind.CrossOver(self.fast, self.slow)
+
+    def next(self) -> None:  # pragma: no cover - behavior defined by Backtrader
+        if not self.position and self.crossover > 0:
+            self.buy(size=self.params.stake)
+        elif self.position and self.crossover < 0:
+            self.close()
+
+
+class BuyAndHoldStrategy(bt.Strategy):
+    params = dict(stake=1.0)
+
+    def next(self) -> None:  # pragma: no cover - behavior defined by Backtrader
+        if not self.position:
+            self.buy(size=self.params.stake)
+
+
+STRATEGY_REGISTRY: Dict[str, Type[bt.Strategy]] = {
+    "ema_crossover": EMACrossoverStrategy,
+    "buy_and_hold": BuyAndHoldStrategy,
+}
+
+
+class PandasPriceData(bt.feeds.PandasData):
+    params = (
+        ("datetime", "timestamp"),
+        ("open", "open"),
+        ("high", "high"),
+        ("low", "low"),
+        ("close", "close"),
+        ("volume", "volume"),
+        ("openinterest", None),
+    )
+
+
+def _prepare_price_frame(price: pd.DataFrame) -> pd.DataFrame:
+    frame = price.copy()
+    frame["timestamp"] = pd.to_datetime(frame["timestamp"], utc=False)
+    frame = frame.sort_values("timestamp")
+    columns = ["open", "high", "low", "close", "volume"]
+    missing = [col for col in columns if col not in frame.columns]
+    if missing:
+        raise ValueError(f"Missing columns for Backtrader feed: {', '.join(missing)}")
+    return frame.set_index("timestamp")
+
+
+def _select_strategy(name: str) -> Type[bt.Strategy]:
+    try:
+        return STRATEGY_REGISTRY[name]
+    except KeyError as exc:  # pragma: no cover - defensive branch
+        raise ValueError(f"Unknown Backtrader strategy '{name}'") from exc
+
+
+def run_backtrader_strategy(
+    price: pd.DataFrame,
+    strategy: str,
+    generation_id: str,
+    output_dir: Path,
+    config: BacktraderConfig | None = None,
+) -> BacktestMetrics:
+    """Execute a Backtrader strategy and persist analytics."""
+
+    ensure_directory(output_dir)
+    config = config or BacktraderConfig()
+
+    prepared = _prepare_price_frame(price)
+    data = PandasPriceData(dataname=prepared)
+
+    cerebro = bt.Cerebro()
+    cerebro.adddata(data)
+    strategy_cls = _select_strategy(strategy)
+    cerebro.addstrategy(strategy_cls, stake=config.stake)
+    cerebro.broker.setcash(config.initial_cash)
+    cerebro.broker.setcommission(commission=config.commission)
+    if config.slippage:
+        cerebro.broker.set_slippage_perc(config.slippage)
+
+    cerebro.addanalyzer(bt.analyzers.TimeReturn, _name="timereturn")
+    cerebro.addanalyzer(bt.analyzers.DrawDown, _name="drawdown")
+
+    results = cerebro.run()
+    strat = results[0]
+
+    returns_dict = strat.analyzers.timereturn.get_analysis()
+    if returns_dict:
+        index = pd.to_datetime(list(returns_dict.keys()))
+        returns_series = pd.Series(list(returns_dict.values()), index=index)
+        returns_series = returns_series.sort_index()
+        returns_series.iloc[0] = 0.0
+    else:
+        first_index = prepared.index[0]
+        returns_series = pd.Series([0.0], index=[first_index])
+
+    equity_curve = (1 + returns_series).cumprod()
+    metrics_dict = performance_metrics(equity_curve)
+
+    final_value = float(cerebro.broker.getvalue())
+    summary = {
+        "generation_id": generation_id,
+        **metrics_dict,
+        "final_value": final_value,
+        "starting_cash": config.initial_cash,
+        "total_return": final_value / config.initial_cash - 1,
+    }
+
+    fig, ax = plt.subplots(figsize=(8, 4))
+    equity_curve.plot(ax=ax, label="Equity")
+    (equity_curve.cummax() - equity_curve).plot(ax=ax, label="Drawdown")
+    ax.legend()
+    ax.set_title(f"Backtrader Equity - {generation_id}")
+    fig.tight_layout()
+    fig.savefig(output_dir / "equity_curve.png", dpi=150)
+    plt.close(fig)
+
+    save_json(output_dir / "backtest_metrics.json", summary)
+
+    return BacktestMetrics(generation_id=generation_id, **metrics_dict)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ numpy>=1.24
 scikit-learn>=1.3
 scipy>=1.10
 matplotlib>=3.7
+backtrader>=1.9
 plotly>=5.14
 typer>=0.9.0
 fastapi>=0.100

--- a/tests/test_backtrader_engine.py
+++ b/tests/test_backtrader_engine.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from app.backtest.backtrader_engine import BacktraderConfig, run_backtrader_strategy
+
+
+def _synthetic_price_frame(periods: int = 120) -> pd.DataFrame:
+    idx = pd.date_range("2020-01-01", periods=periods, freq="D")
+    trend = np.linspace(0, 5, periods)
+    noise = np.sin(np.linspace(0, 8, periods))
+    close = 100 + trend + noise
+    rng = np.random.default_rng(42)
+    frame = pd.DataFrame(
+        {
+            "timestamp": idx,
+            "open": close + rng.normal(0, 0.2, periods),
+            "high": close + np.abs(rng.normal(0, 0.3, periods)),
+            "low": close - np.abs(rng.normal(0, 0.3, periods)),
+            "close": close,
+            "volume": rng.integers(1_000, 5_000, periods),
+        }
+    )
+    return frame
+
+
+def test_backtrader_strategy_generates_metrics(tmp_path: Path) -> None:
+    price = _synthetic_price_frame()
+    config = BacktraderConfig(initial_cash=10_000, commission=0.0, stake=10)
+    metrics = run_backtrader_strategy(
+        price=price,
+        strategy="ema_crossover",
+        generation_id="GEN_TEST",
+        output_dir=tmp_path,
+        config=config,
+    )
+
+    assert metrics.generation_id == "GEN_TEST"
+    assert isinstance(metrics.cagr, float)
+    assert (tmp_path / "backtest_metrics.json").exists()
+    assert (tmp_path / "equity_curve.png").exists()


### PR DESCRIPTION
## Summary
- add a Backtrader-powered backtest engine with strategy registry, equity curve export, and metrics capture
- extend the CLI with reusable price filtering so training/backtests can target historical windows or specific symbols
- add the Backtrader dependency and a regression test covering the new engine helper

## Testing
- pytest *(fails locally: missing pandas/numpy dependencies in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e082a3a228832194e7a0268bedb241